### PR TITLE
Separate not shipped and shipped orders to different tables (in 'my orders' view)

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { SecurityInterceptor } from './security-interceptor';
 import { UserService } from './userService';
 
 import { environment } from 'src/environments/environment';
+import { ProcessedOrdersComponent } from './processed-orders/processed-orders.component';
 
 @NgModule({
   declarations: [
@@ -44,7 +45,8 @@ import { environment } from 'src/environments/environment';
     OrderDetailsComponent,
     TrackingNumberComponent,
     LoginPageComponent,
-    OrderTableComponent
+    OrderTableComponent,
+    ProcessedOrdersComponent
   ],
   imports: [
     AppRoutingModule,

--- a/frontend/src/app/my-orders/my-orders.component.html
+++ b/frontend/src/app/my-orders/my-orders.component.html
@@ -1,3 +1,5 @@
 <div>
     <order-table [orders]="orders"></order-table>
 </div>
+<br>
+<app-processed-orders></app-processed-orders>

--- a/frontend/src/app/my-orders/my-orders.component.ts
+++ b/frontend/src/app/my-orders/my-orders.component.ts
@@ -15,11 +15,9 @@ export class MyOrdersComponent implements OnInit {
   ngOnInit(): void {
     this.orderControllerService.getMyOrders().subscribe(myOrders => {
       this.orders = myOrders.filter(myOrder => {
-        let now = new Date().getTime();
-        let oneDaySinceLastUpdate = new Date(myOrder.lastUpdate!.toString()).getTime() + 86400000;
-        return (oneDaySinceLastUpdate > now && myOrder.status == 'SHIPPED') || (myOrder.status != 'SHIPPED');
+        return (myOrder.status != 'SHIPPED');
       });
-    });    
-  }  
+    });
+  }
 
 }

--- a/frontend/src/app/processed-orders/processed-orders.component.html
+++ b/frontend/src/app/processed-orders/processed-orders.component.html
@@ -1,0 +1,3 @@
+<div>
+  <order-table [orders]="orders"></order-table>
+</div>

--- a/frontend/src/app/processed-orders/processed-orders.component.spec.ts
+++ b/frontend/src/app/processed-orders/processed-orders.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProcessedOrdersComponent } from './processed-orders.component';
+
+describe('ProcessedOrdersComponent', () => {
+  let component: ProcessedOrdersComponent;
+  let fixture: ComponentFixture<ProcessedOrdersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ProcessedOrdersComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProcessedOrdersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/processed-orders/processed-orders.component.ts
+++ b/frontend/src/app/processed-orders/processed-orders.component.ts
@@ -1,0 +1,23 @@
+import {Component, OnInit} from '@angular/core';
+import {Order, OrderControllerService} from 'generated-client';
+
+@Component({
+  selector: 'app-processed-orders',
+  templateUrl: './processed-orders.component.html',
+  styleUrls: ['./processed-orders.component.css']
+})
+export class ProcessedOrdersComponent implements OnInit {
+
+  orders: Order[] = [];
+
+  constructor(protected orderControllerService: OrderControllerService) { }
+
+  ngOnInit(): void {
+    this.orderControllerService.getMyOrders().subscribe(myOrders => {
+      this.orders = myOrders.filter(myOrder => {
+        return (myOrder.status == 'SHIPPED');
+      });
+    });
+  }
+
+}


### PR DESCRIPTION
Related task: https://github.com/petr-vanis-cgi/bonnie/issues/65
I have added a shipped oreders table, and now it looks like that: [link to screenshot](https://drive.google.com/drive/folders/17yhQ5AAT6lB9Y1qnhRsJS8CTtEkGrUOc?usp=sharing)